### PR TITLE
Fix typo: Remove duplicate 'how' in linters_overview.md

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/00._Course_Material/00._Meta_Course_Material/linters_overview.md
+++ b/00._Course_Material/00._Meta_Course_Material/linters_overview.md
@@ -1,6 +1,6 @@
 # Linting Overview
 
-In this course it is a requirement for your exam project to adhere to clean code style guides. But how how you achieve this is up to you. 
+In this course it is a requirement for your exam project to adhere to clean code style guides. But how you achieve this is up to you. 
 
 Consider setting up a linter early in the semester to get used to its suggestions.
 


### PR DESCRIPTION
Fixed typo in linters_overview.md where "how how you" was changed to "how you".